### PR TITLE
Avoid adding duplicate groups to the select.

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,6 +425,8 @@ async function updateUI(params = null) {
   let groups = [...new Set(metrics.map(m => m.split('_')[2]))];
   groups = groups.sort((a, b) => a.localeCompare(b));
 
+  $('.groups').empty();
+
   for (let g of groups) {
     $('.groups').append($('<option>', {
       value: g,


### PR DESCRIPTION
Switching the version / branch will re-fetch the use counter names and populate the group select but doesn't remove the existing entries.